### PR TITLE
Update ingress to use v1 for compatibility

### DIFF
--- a/manifests/base/README.md
+++ b/manifests/base/README.md
@@ -32,7 +32,7 @@ configMapGenerator:
 patchesJson6902:
   - target:
       group: networking.k8s.io
-      version: v1beta1
+      version: v1
       kind: Ingress
       name: mtls
     patch: |-

--- a/manifests/base/ingress.yml
+++ b/manifests/base/ingress.yml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: mtls
@@ -14,6 +14,9 @@ spec:
       http:
         paths:
           - path: "/"
+            pathType: Prefix
             backend:
-              serviceName: mtls
-              servicePort: http
+              service:
+                name: mtls
+                port:
+                  name: http


### PR DESCRIPTION
ingress-nginx version 1.0.0 removes the v1beta api
https://github.com/kubernetes/ingress-nginx/releases/tag/v1.0.0-alpha.1