### PR TITLE
wipe GPG home when keys change

### DIFF
--- a/manifests/base/kustomization.yml
+++ b/manifests/base/kustomization.yml
@@ -25,5 +25,5 @@ secretGenerator:
       - ./secrets/ca.key
 images:
   - name: drgrove/mtls-server
-    newTag: v0.19.0
-    digest: sha256:eb66f949f0f29ba90e1d6014f08d049feb79b33d1954055d398e7566f0ba2bf4
+    newTag: v0.19.1
+    digest: sha256:d9247721f1ce7a444311a3cdcdffcd1197243ffa5194b9a6af10daeac5d71240

--- a/manifests/configmap-seed/add-sidecars.patch.yml
+++ b/manifests/configmap-seed/add-sidecars.patch.yml
@@ -14,6 +14,10 @@ spec:
               mountPath: /tmp/seeds/user
             - name: sc-admin-keys-volume
               mountPath: /tmp/seeds/admin
+            - name: gnupg-user
+              mountPath: /home/mtls/secrets/gnupg/
+            - name: gnupg-admin
+              mountPath: /home/mtls/secrets/admin_gnupg/
         - name: mtls-init-user-keys
           image: kiwigrid/k8s-sidecar:1.14.2
           env:
@@ -23,6 +27,8 @@ spec:
               value: /tmp/user_keys
             - name: SCRIPT
               value: /tmp/restart-mtls.sh
+            - name: GNUPGHOME
+              value: /tmp/gnupg_home
           volumeMounts:
             - name: sc-user-keys-volume
               mountPath: /tmp/user_keys
@@ -30,6 +36,8 @@ spec:
               mountPath: /tmp/restart-mtls.sh
               subPath: "restart-mtls.sh"
               readOnly: true
+            - name: gnupg-user
+              mountPath: /tmp/gnupg_home
         - name: mtls-init-admin-keys
           image: kiwigrid/k8s-sidecar:1.14.2
           env:
@@ -39,6 +47,8 @@ spec:
               value: /tmp/admin_keys
             - name: SCRIPT
               value: /tmp/restart-mtls.sh
+            - name: GNUPGHOME
+              value: /tmp/gnupg_home
           volumeMounts:
             - name: sc-admin-keys-volume
               mountPath: /tmp/admin_keys
@@ -46,10 +56,16 @@ spec:
               mountPath: /tmp/restart-mtls.sh
               subPath: "restart-mtls.sh"
               readOnly: true
+            - name: gnupg-admin
+              mountPath: /tmp/gnupg_home
       volumes:
         - name: sc-user-keys-volume
           emptyDir: {}
         - name: sc-admin-keys-volume
+          emptyDir: {}
+        - name: gnupg-user
+          emptyDir: {}
+        - name: gnupg-admin
           emptyDir: {}
         - name: mtls-restart-script
           configMap:

--- a/manifests/configmap-seed/files/restart-mtls.sh
+++ b/manifests/configmap-seed/files/restart-mtls.sh
@@ -1,5 +1,7 @@
-#!/bin/bash
+#!/bin/sh
+
+echo "Cleaning GPG home"
+rm -r ${GNUPGHOME}/*
 
 echo "Restarting mtls process in main container"
-
 killall uwsgi

--- a/manifests/configmap-seed/kustomization.yml
+++ b/manifests/configmap-seed/kustomization.yml
@@ -6,7 +6,6 @@ resources:
   - mtls-serviceaccount.yml
 patches:
   - add-sidecars.patch.yml
-  - ephemeral-keyring.patch.yml
 configMapGenerator:
   - name: mtls-restart-script
     files:
@@ -15,4 +14,3 @@ images:
   - name: kiwigrid/k8s-sidecar
     newTag: 1.14.2
     digest: sha256:80d5a85a72762aef6181941eaccc8449f3b46ccab932e7362d2d71726681d1ec
-

--- a/mtls_server/sync.py
+++ b/mtls_server/sync.py
@@ -46,22 +46,28 @@ class Sync(object):
                         f_path = os.path.join(seed_dir, f)
                         if os.path.isfile(f_path):
                             fingerprint = f.split(".")[0]
-                            with open(f_path, "r") as gpg_data:
-                                gpg_data = str(gpg_data.read())
-                                if trust == "admin":
-                                    import_and_trust(gpg_data, self.admin_gpg)
-                                # If we add an admin, they're also a user,
-                                # so we can just pull the fingerprint once
-                                # and use that for logging. It will only show
-                                # it's being 'added' to the admin store, but
-                                # that's fine since that assumption is already
-                                # made
-                                fingerprint = import_and_trust(
-                                    gpg_data, self.user_gpg
+                            try:
+                                with open(f_path, "r") as key_file:
+                                    logger.debug(f"Opening {f_path} as ascii")
+                                    gpg_data = key_file.read()
+                            except UnicodeDecodeError:
+                                with open(f_path, "rb") as key_file:
+                                    logger.debug(f"Opening {f_path} as binary")
+                                    gpg_data = key_file.read()
+                            if trust == "admin":
+                                import_and_trust(gpg_data, self.admin_gpg)
+                            # If we add an admin, they're also a user,
+                            # so we can just pull the fingerprint once
+                            # and use that for logging. It will only show
+                            # it's being 'added' to the admin store, but
+                            # that's fine since that assumption is already
+                            # made
+                            fingerprint = import_and_trust(
+                                gpg_data, self.user_gpg
+                            )
+                            logger.info(
+                                "Added {fp} to {t} Store".format(
+                                    fp=fingerprint, t=trust
                                 )
-                                logger.info(
-                                    "Added {fp} to {t} Store".format(
-                                        fp=fingerprint, t=trust
-                                    )
-                                )
+                            )
         logger.info("Completed seeding of Trust Databases")


### PR DESCRIPTION
mtls-server is locked down read-only, and so requires a volume mounted at the configured GPG home. This patch mounts an emptyDir there, but expands the restart script to wipe it so that keys removed from the seed dir are also removed from the keychain.

The second commit allows `mtls-server.sync` to handle both binary and ASCII seed data.