### PR TITLE
set lazy-apps to avoid threading bug

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -8,3 +8,4 @@ http-socket = :4000
 vacuum = true
 enable-threads = true
 die-on-term = true
+lazy-apps = true


### PR DESCRIPTION
This should fix the issue of slow startup times when there are a lot of GPG keys configured.

`create_app` instantiates `Handler`, which instantiates `CertProcessor`, which [spawns some background threads](https://github.com/drGrove/mtls-server/blob/b19608e41881e08571b35484de95c1aa296d9f5d/mtls_server/cert_processor.py#L78-L80) for refreshing keys from the keyserver. Because these threads are spawned before `create_app` returns, it triggers a [bug in uWSGI](https://github.com/unbit/uwsgi/issues/2387) where threading prior to `fork()` creates a GIL deadlock. This PR works around that bug by setting `lazy-apps`, which delays app creation until after the server forks.